### PR TITLE
Potential fix for code scanning alert no. 10: Uncontrolled data used in path expression

### DIFF
--- a/bindings/wasm/tests-browser/serve.mjs
+++ b/bindings/wasm/tests-browser/serve.mjs
@@ -116,6 +116,13 @@ const server = http.createServer(async (req, res) => {
     }
 
     const requestedPath = path.normalize(p).replace(/^([/\\])+/, "");
+    if (
+        path.isAbsolute(requestedPath) ||
+        requestedPath.split(/[\\/]+/).includes("..")
+    ) {
+        res.writeHead(403).end("forbidden");
+        return;
+    }
     const file = path.resolve(OUT_REAL, requestedPath);
 
     let realFile;

--- a/bindings/wasm/tests-browser/serve.mjs
+++ b/bindings/wasm/tests-browser/serve.mjs
@@ -8,7 +8,7 @@
  */
 
 import http from "node:http";
-import { readFile, mkdir, writeFile, copyFile } from "node:fs/promises";
+import { readFile, mkdir, writeFile, copyFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import esbuild from "esbuild";
@@ -18,6 +18,7 @@ const PKG_ROOT = path.resolve(__dirname, "..");
 const OUT = path.join(__dirname, ".serve");
 
 await mkdir(OUT, { recursive: true });
+const OUT_REAL = await realpath(OUT);
 
 // The consumer references all six subpaths so the smoke test covers
 // every algo in one page load.
@@ -115,17 +116,25 @@ const server = http.createServer(async (req, res) => {
     }
 
     const requestedPath = path.normalize(p).replace(/^([/\\])+/, "");
-    const file = path.resolve(OUT, requestedPath);
+    const file = path.resolve(OUT_REAL, requestedPath);
 
-    // Containment check: reject anything that resolves outside OUT.
-    if (file !== OUT && !file.startsWith(OUT + path.sep)) {
+    let realFile;
+    try {
+        realFile = await realpath(file);
+    } catch {
+        res.writeHead(404).end("not found");
+        return;
+    }
+
+    // Containment check on canonical paths: reject anything outside OUT.
+    if (realFile !== OUT_REAL && !realFile.startsWith(OUT_REAL + path.sep)) {
         res.writeHead(403).end("forbidden");
         return;
     }
 
     try {
-        const body = await readFile(file);
-        const ext = path.extname(file);
+        const body = await readFile(realFile);
+        const ext = path.extname(realFile);
         res.writeHead(200, { "Content-Type": MIME[ext] || "application/octet-stream" });
         res.end(body);
     } catch {

--- a/bindings/wasm/tests-browser/serve.mjs
+++ b/bindings/wasm/tests-browser/serve.mjs
@@ -100,14 +100,29 @@ const MIME = {
 };
 
 const server = http.createServer(async (req, res) => {
-    let p = decodeURIComponent((req.url || "/").split("?")[0]);
+    let p;
+    try {
+        p = decodeURIComponent((req.url || "/").split("?")[0]);
+    } catch {
+        res.writeHead(400).end("bad request");
+        return;
+    }
+
     if (p === "/") p = "/index.html";
-    const file = path.resolve(OUT, p.replace(/^\//, ""));
+    if (p.includes("\0")) {
+        res.writeHead(400).end("bad request");
+        return;
+    }
+
+    const requestedPath = path.normalize(p).replace(/^([/\\])+/, "");
+    const file = path.resolve(OUT, requestedPath);
+
     // Containment check: reject anything that resolves outside OUT.
     if (file !== OUT && !file.startsWith(OUT + path.sep)) {
         res.writeHead(403).end("forbidden");
         return;
     }
+
     try {
         const body = await readFile(file);
         const ext = path.extname(file);


### PR DESCRIPTION
Potential fix for [https://github.com/dupontcyborg/compress-utils/security/code-scanning/10](https://github.com/dupontcyborg/compress-utils/security/code-scanning/10)

General fix: strictly validate/normalize request paths before file access, enforce containment under `OUT`, and reject malformed URL encodings early.

Best fix here (without changing behavior materially) in `bindings/wasm/tests-browser/serve.mjs`:
- Wrap `decodeURIComponent` in a `try/catch` and return `400` for invalid encodings.
- Normalize the request path and explicitly reject NUL bytes.
- Keep/strengthen the existing root-containment check before `readFile`.
- Use the validated/resolved path variable as the only value passed to `readFile`.

This keeps static file serving behavior while making the trust boundary explicit and robust.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
